### PR TITLE
Enable all features to socket2 dependency

### DIFF
--- a/local_agent_rs/Cargo.toml
+++ b/local_agent_rs/Cargo.toml
@@ -17,7 +17,7 @@ webpki = "0.22.4"
 webpki-roots = "^0.26.3"
 log = "0.4.22"
 env_logger = "0.11.5"
-socket2 = "0.5.7"
+socket2 = { version = "0.5.7", features = ["all"] }
 async-trait = "0.1.81"
 bincode = "1.3.3"
 test-log = ">=0.2.16"


### PR DESCRIPTION
This change should fix the build of python-proton-vpn-local-agent

See https://bugzilla.opensuse.org/show_bug.cgi?id=1253255#c6