### PR TITLE
Install default rustls crypto provider to prevent panic on Debian 14

### DIFF
--- a/local_agent_rs/Cargo.toml
+++ b/local_agent_rs/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio-rustls = { version="0.26.0", features = ["tls12"] }
+tokio-rustls = { version="0.26.0", features = ["tls12", "ring"] }
 tokio = { version = "1.38.0", features = ["full"] }
 serde = {version="1.0.201", features = ["derive"] }
 rustls-pki-types = "1.7.0"

--- a/local_agent_rs/src/agent_connector.rs
+++ b/local_agent_rs/src/agent_connector.rs
@@ -140,6 +140,11 @@ impl AgentConnector {
     pub async fn connect(
         params: ConnectParams
     ) -> Result<AgentConnection> {
+        // Rustls > 0.22 requires setting the crypto provider if we have multiple
+        // or to explicitly install the default. We install ring's default since we
+        // enabled it in features. Ignore error if already installed.
+        let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+
         // Build the root certificate store
         let root_cert_store = build_root_cert_store()?;
 

--- a/python-proton-vpn-local-agent/Cargo.lock
+++ b/python-proton-vpn-local-agent/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",


### PR DESCRIPTION
Resolves #12

### Summary
This PR fixes a Rust panic when running `proton-vpn-local-agent` in environments with `rustls` 0.23+ (such as Debian 14).

### Changes
* Added `"ring"` feature to `tokio-rustls` dependency in `Cargo.toml`.
* Explicitly invoked `tokio_rustls::rustls::crypto::ring::default_provider().install_default()` inside `AgentConnector::connect()` before generating the `TlsConnector` to satisfy the missing crypto provider requirement.